### PR TITLE
Convert markdown to HTML when adding to messages

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -11,6 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
 </head>
 <body>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <div id="head-text">
         <h1>
             AI Chatbot

--- a/public/script.js
+++ b/public/script.js
@@ -21,8 +21,9 @@ async function loadConversationHistory() {
     const data = await response.json();
     if (data.interactions && data.interactions.length > 0) {
         data.interactions.forEach(interaction => {
+	    let formatResponse = marked.parse(interaction.botResponse);
             messagesContainer.insertAdjacentHTML('beforeend', `<p class="message">You: ${interaction.userInput}</p>`);
-            messagesContainer.insertAdjacentHTML('beforeend', `<p class="message">Bot: ${interaction.botResponse}</p>`);
+            messagesContainer.insertAdjacentHTML('beforeend', `<p class="message">Bot: ${formatResponse}</p>`);
             // Add to conversation history
             conversationHistory.push({ role: 'user', content: interaction.userInput });
             conversationHistory.push({ role: 'assistant', content: interaction.botResponse });
@@ -70,10 +71,12 @@ async function sendMessage() {
 
         const data = await response.json();
 
+	let formatResponse = marked.parse(data.botResponse);
+
         conversationHistory.push({ role: 'user', content: inputText })
         conversationHistory.push({ role: 'assistant', content: data.botResponse})
 
-        messagesContainer.insertAdjacentHTML('beforeend', `<p class="message">Bot: ${data.botResponse}</p>`);
+        messagesContainer.insertAdjacentHTML('beforeend', `<p class="message">Bot: ${formatResponse}</p>`);
         messagesContainer.insertAdjacentHTML('beforeend', `<p class="message">Relevant Links:</p>`);
         data.searchResults.forEach(result => {
             messagesContainer.insertAdjacentHTML('beforeend', `<a href="${result.url}"target="_blank">${result.title}</a><p>${result.snippet}</p>`)}


### PR DESCRIPTION
Uses the [marked](https://www.npmjs.com/package/marked) library to convert the AI's markdown to HTML. The history remains in markdown to better aid the AI, and the conversion happens when the text is displayed to the user.